### PR TITLE
Remove rails validation tests

### DIFF
--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -4,11 +4,6 @@ RSpec.describe Quote, type: :model do
   let(:quote) { FactoryGirl.create(:quote) }
   let(:user) { FactoryGirl.create(:user) }
 
-  it "requires a body" do
-    quote.body = nil
-    expect(quote).to be_invalid
-  end
-
   describe "#score" do
     before do
       create(:vote, value: 2, quote: nil)

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,11 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe Vote, type: :model do
-  let(:vote) { create(:vote) }
-  describe "validation" do
-    it 'requires a value' do
-      vote.value = nil
-      expect(vote).to be_invalid
-    end
-  end
 end


### PR DESCRIPTION
I had created tests on the models early on to just practice testing syntax but since they're only rails validations it is pointless to still have them in the test suite.  At least now they're letting me practice proper git as well.
