### PR TITLE
Select2 autocomplete employees as quote sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'turbolinks'
 gem 'simple_form'
+gem "select2-rails"
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    select2-rails (4.0.1)
+      thor (~> 0.14)
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -220,6 +222,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  select2-rails
   simple_form
   spring
   turbolinks

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,8 @@
 // about supported directives.
 //
 //= require jquery
-//= require bootstrap-sprockets
 //= require jquery_ujs
+//= require bootstrap-sprockets
 //= require turbolinks
+//= require select2
 //= require_tree .

--- a/app/assets/javascripts/modify_select.js
+++ b/app/assets/javascripts/modify_select.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  $("#quote_quoted_person").select2({
+    theme: "bootstrap"
+  });
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,8 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
+ *= require select2
+ *= require select2-bootstrap
  *= require_tree .
  *= require_self
  */

--- a/app/views/quotes/_form.html.erb
+++ b/app/views/quotes/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @quote do |f| %>
-  <%= f.input :quoted_person %>
+  <%= f.input :quoted_person, collection: t(:users) %>
   <%= f.input :body %>
   <%= f.input :location %>
   Please format as shown below:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,23 @@
 
 en:
   hello: "Hello world"
+  users: [
+    "Adam Mueller",
+    "Alex Blackie",
+    "Amanda Healey",
+    "Andrew Stewart",
+    "Brendan Deere",
+    "Chris Todorov",
+    "Clarke Brundson",
+    "Dylan Kendal",
+    "Gray Gilmore",
+    "Gregor MacDougall",
+    "Jared Norman",
+    "John Hawthorn",
+    "Kevin Attfield",
+    "Luuk Veenis",
+    "Murphy Stroppa",
+    "Richard Wilson",
+    "Sean Taylor",
+    "Susan Aili"
+  ]


### PR DESCRIPTION
The Quoted person field was changed to a select field with employee options provided.  

My understanding was this is going to be used in house for hosting quotes said by people working here so this default tendency of using just employees makes sense to me.  In the future the form will be on one line and we could add a toggle switch beneath the box that would grey out this select field and bring a new field into view where someone could type in a name of someone that isn't an employee.  

Also I imagine most quotes will be supplied through slack so we can implement some kind of fuzzy match towards this list of prepopulated employees.
