### PR TITLE
Convert validations to shoulda gem sytax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
 end
+
+group :test do
+  gem "shoulda-matchers", "~> 3.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-matchers (3.1.0)
+      activesupport (>= 4.0.0)
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -245,6 +247,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers (~> 3.0)
   simple_form
   turbolinks
   uglifier (>= 1.3.0)

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe Quote, type: :model do
   let(:quote) { FactoryGirl.create(:quote) }
   let(:user) { FactoryGirl.create(:user) }
 
-  it "requires a body" do
-    quote.body = nil
-    expect(quote).to be_invalid
-  end
+  it { is_expected.to validate_presence_of(:body) }
 
   describe "#score" do
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { create(:user) }
-
   describe 'validations' do
-    it 'requires an email' do
-      user.email = nil
-      expect(user).to be_invalid
-    end
+    it { is_expected.to validate_presence_of(:email) }
   end
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Vote, type: :model do
-  it { is_expected.to validate_presence_of(:value) }
+  let(:user) { create(:user) }
+  let(:quote) { create(:quote) }
+  let(:vote) { create(:vote, user: user, quote: quote) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:value) }
+
+    describe "uniqueness of user scoped to quote" do
+      subject { create(:vote) }
+
+      it "doesn't allow someone to vote on a quote twice" do
+        expect{ create(:vote, value: vote.value, user: user, quote: quote) }.
+          to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
 end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,11 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Vote, type: :model do
-  let(:vote) { create(:vote) }
-  describe "validation" do
-    it 'requires a value' do
-      vote.value = nil
-      expect(vote).to be_invalid
-    end
-  end
+  it { is_expected.to validate_presence_of(:value) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,13 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+
+    with.library :rails
+  end
+end
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
The validations on the models were converted to the shoulda gem one line syntax when possible as it is more clear and easier to maintain.

replacing the #26 PR as that was pulling into the incorrect branch.
