### PR TITLE
Change votes to enum and method

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -6,19 +6,15 @@ class VotesController < ApplicationController
     if vote.save
       flash[:notice] = "Voted!"
     else
-      flash[:alert] = "Something went wrong!"
+      flash[:alert] = "Vote failed to create.  Had you already voted?"
     end
     redirect_to quotes_path
   end
 
   def update
-    @quote = current_quote
-    vote = @quote.votes.find_by!(user: current_user)
-    if vote.update vote_params
-      redirect_to quotes_path, notice: "Vote updated"
-    else
-      redirect_to quotes_path, alert: "Vote failed to update"
-    end
+    vote = current_quote.votes.find_by!(user: current_user)
+    vote.update vote_params
+    redirect_to quotes_path, notice: "Vote updated" # error thrown if update fails
   end
 
   def destroy

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,21 +1,15 @@
 class Vote < ActiveRecord::Base
-  VALID_VALUES = [-2, -1, 1, 2]
-  VOTE_TYPES = [
-    ["I hate it", -2].freeze,
-    ["I'm against it", -1].freeze,
-    ["I like it", 1].freeze,
-    ["I love it", 2].freeze
-  ].freeze
+  enum value: { hate_it: -2, dislike_it: -1, like_it: 1, love_it: 2 }
 
-  validates :value, presence: true
+  validates :value, presence: true, inclusion: { in: Vote.values.keys }
   validates :user_id, uniqueness: { scope: :quote_id }
-  validate :validate_value
 
   belongs_to :user
   belongs_to :quote
 
-  def validate_value
-    return true if VALID_VALUES.include? value
-    errors.add(:value, "Invalid value entered")
+  def self.enum_key_to_sentence(enum_key)
+    sentence = enum_key.dup
+    sentence = "I #{sentence}"
+    sentence.tr!("_", " ")
   end
 end

--- a/app/views/votes/_voting.html.erb
+++ b/app/views/votes/_voting.html.erb
@@ -1,11 +1,19 @@
 <% if @user_votes.include? vote %>
-  <% Vote::VOTE_TYPES.each do |reason, value| %>
-    <%= link_to reason, quote_vote_path(quote, vote, { vote: { value: value } } ), method: :patch %>
+  <% Vote.values.keys.each do |reason| %>
+
+    <%= link_to Vote.enum_key_to_sentence(reason),
+      quote_vote_path(quote, vote, { vote: { value: reason } } ), method: :patch %>
+
   <% end %>
+
   <%= link_to "Erase my vote", quote_vote_path(quote, vote), method: :delete %>
+
 <% else %>
-  <% Vote::VOTE_TYPES.each do |reason, value| %>
-    <%= link_to reason, quote_votes_path(quote, { vote: { value: value } } ), method: :post %>
+
+  <% Vote.values.keys.each do |reason| %>
+
+    <%= link_to Vote.enum_key_to_sentence(reason),
+      quote_votes_path(quote, { vote: { value: reason } } ), method: :post %>
+
   <% end %>
 <% end %>
-

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -31,16 +31,9 @@ RSpec.describe VotesController, type: :controller do
         end
       end
       context "with invalid parameters" do
-        let(:params) { { quote_id: quote.id, vote: { value: 55 } } }
-        it { is_expected.to redirect_to quotes_path }
-
-        it "sets a flash alert message" do
-          subject
-          expect(flash[:alert]).to include("Something")
-        end
-
+        let(:params) { { quote_id: quote.id, vote: { value: :i_am_indifferent } } }
         it "doesn't create a vote" do
-          expect { subject }.to change { Vote.count }.by(0)
+          expect { subject }.to raise_error(ArgumentError)
         end
       end
     end
@@ -57,12 +50,12 @@ RSpec.describe VotesController, type: :controller do
       before { login_with user }
       context "with a user that owns the vote" do
         context "with a valid update value" do
-          let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: 2 } } }
+          let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: :love_it } } }
           it { is_expected.to redirect_to quotes_path }
 
           it "changes the vote value" do
             subject
-            expect(vote.reload.value).to eq(2)
+            expect(vote.reload.value).to eq("love_it")
           end
 
           it "sets a flash notice" do
@@ -71,18 +64,17 @@ RSpec.describe VotesController, type: :controller do
           end
         end
         context "with an invalid update value" do
-          let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: 99 } } }
-          it { is_expected.to redirect_to quotes_path }
+          let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: :unsure } } }
 
           it "doesn't change the vote value" do
-            subject
-            expect(vote.reload.value).to eq(1)
+            expect { subject }.to raise_error(ArgumentError)
           end
         end
       end
       context "with a user that doesn't own the vote" do
         before { login_with create(:user) }
-        let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: 2 } } }
+        let(:params) { { quote_id: quote.id, id: vote.id, vote: { value: :love_it } } }
+
         it "raises an error" do
           expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
         end

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :vote do
-    value { 1 }
+    value { :like_it }
     user
     quote
   end

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Quote, type: :model do
   end
 
   describe "#score" do
+    number = Vote.values.keys.last
     before do
       create(:vote, value: 2, quote: nil)
       create(:vote, quote: quote, value: 2)
@@ -17,7 +18,7 @@ RSpec.describe Quote, type: :model do
     end
 
     it "has a score function that tallies votes" do
-      expect(quote.score).to eq(4)
+      expect(quote.score).to eq(Vote.values[number] * 2)
     end
   end
 end


### PR DESCRIPTION
This is an alternative to #19 which utilized I18n.  That functionality was replaced by placing a method on the vote class that will take in the enum key and turn it into the same sentence we were using before.  One concern with this style is it locks us into an "I ..." statements for now but considering the use that should be workable with. 
