### PR TITLE
Change quote form to a single line

### DIFF
--- a/app/assets/stylesheets/quotes.scss
+++ b/app/assets/stylesheets/quotes.scss
@@ -1,5 +1,0 @@
-.quote-example {
-  span, q {
-    font-style: italic;
-  }
-}

--- a/app/views/quotes/_form.html.erb
+++ b/app/views/quotes/_form.html.erb
@@ -1,10 +1,9 @@
-<%= simple_form_for @quote do |f| %>
+<%= simple_form_for @quote, html: { class: "form-inline" } do |f| %>
   <%= f.input :quoted_person %>
-  <%= f.input :body %>
-  <%= f.input :location %>
-  Please format as shown below:
-  <div class="quote-example">
-    <span>Quoted Person</span> said, <q>body</q>, <span>location</span>.
-  </div>
-  <%= f.submit "Submit Quote" %>
+  said
+  <%= f.input :body, label: false %>
+  ,
+  <%= f.input :location, label: false %>
+  .
+  <%= f.submit "Submit Quote", class: "btn btn-default" %>
 <% end %>


### PR DESCRIPTION
This is a nicer user experience and eliminates the need for the example
to be shown beneath the quote.  In the future likely moving the add
quote to a collapsible element on the main index(es).
