### PR TITLE
Add confirm on deletion of quote

### DIFF
--- a/app/views/quotes/_quote.html.erb
+++ b/app/views/quotes/_quote.html.erb
@@ -1,6 +1,6 @@
 <%= quote.quoted_person %> said, <q><%= quote.body %></q>, <%= quote.location %>.
 <% if quote.created_by == current_user %>
-  <%= link_to "delete quote", quote_path(quote), method: :delete  %>
+  <%= link_to "delete quote", quote_path(quote), method: :delete, data: { confirm: "Delete quote?" } %>
   <%= link_to "edit quote", edit_quote_path(quote) %>
 <% end %>
 <%=


### PR DESCRIPTION
This prevents someone accidentally clicking delete quote and erasing the
entire quote.
