### PR TITLE
Fix method name typo

### DIFF
--- a/app/controllers/api/v1/quotes_controller.rb
+++ b/app/controllers/api/v1/quotes_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::QuotesController < ActionController::Base
   def quoted_person
     return unless raw_params[:quoted_person]
     person = raw_params[:quoted_person]
-    if person.starts_with('@')
+    if person.start_with?('@')
       Person.find_or_create_by(slack_name: person)
     else
       Person.find_or_create_by(full_name: person)

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -60,7 +60,7 @@ class QuotesController < ApplicationController
   def quoted_person
     return unless raw_params[:quoted_person]
     person = raw_params[:quoted_person]
-    if person.starts_with('@')
+    if person.start_with?('@')
       Person.find_or_create_by(slack_name: person)
     else
       Person.find_or_create_by(full_name: person)


### PR DESCRIPTION
Made a typo when implementing Chris's code review.  This fixes it.  
